### PR TITLE
Update FIAT-500X generations: add facelifts and redesigns with references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Fiat 500X
 
+This repository contains signal set configurations for the Fiat 500X, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Fiat 500X.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,5 +1,23 @@
+references:
+  - "https://en.wikipedia.org/wiki/Fiat_500X"
+
 generations:
   - name: "First Generation"
     start_year: 2014
-    end_year: null
-    description: "The Fiat 500X is a subcompact crossover SUV that combines 500-inspired styling cues with the practicality and higher ride height of an SUV. Built on the Small Wide 4×4 platform shared with the Jeep Renegade, it represents Fiat's entry into the rapidly growing small crossover segment. The exterior design successfully translates the retro-inspired elements of the 500 city car onto a larger vehicle, featuring rounded headlights, a curved hood, and the distinctive Fiat front grille. Initially offered with a wide range of engines including 1.4L MultiAir turbocharged petrol units, 1.6L and 2.0L Multijet diesels, and a 2.4L Tigershark in North America, the powertrain lineup was later rationalized. A significant update in 2018 refreshed the styling and introduced new turbocharged engines in North America, including a 1.3L turbo producing 177 HP. The interior features a body-colored dashboard panel reminiscent of the standard 500, with a central touchscreen infotainment system that has been updated throughout the vehicle's life. Available in front-wheel or all-wheel drive configurations, the 500X offers more off-road capability than typical city-focused crossovers, particularly in Trekking and Cross variants. Throughout its production, the 500X has received minor updates to styling, technology, and equipment levels, but the fundamental design has remained consistent. A soft-top variant called the 500X Dolcevita was introduced in 2021, featuring a power-retractable canvas roof. The 500X represents Fiat's most successful expansion of the 500 design language beyond the original city car, providing a practical family vehicle with distinctive Italian style."
+    end_year: 2018
+    description: "The initial Fiat 500X (Type 334) is a subcompact crossover SUV that combines 500-inspired styling cues with the practicality and higher ride height of an SUV. Built on the Small Wide 4×4 platform shared with the Jeep Renegade, it represents Fiat's entry into the rapidly growing small crossover segment. The exterior design successfully translates the retro-inspired elements of the 500 city car onto a larger vehicle, featuring rounded headlights, a curved hood, and the distinctive Fiat front grille. At launch, it offered a range of engines including 1.4L MultiAir turbocharged petrol units, 1.6L and 2.0L Multijet diesels. In North America, a 2.4L Tigershark was available. The interior features a body-colored dashboard panel reminiscent of the standard 500, with a central touchscreen infotainment system. Available in front-wheel or all-wheel drive configurations, the 500X offers more off-road capability than typical city-focused crossovers, particularly in Trekking and Cross variants."
+
+  - name: "First Generation (2018 Facelift)"
+    start_year: 2018
+    end_year: 2019
+    description: "The 2018 facelift refreshed the exterior styling of the 500X while maintaining the same platform. The refresh included updated headlights, grille, bumpers, and interior enhancements with updated infotainment systems. The powertrain lineup continued to offer the proven engine options from the initial generation."
+
+  - name: "First Generation (2019 Redesign)"
+    start_year: 2019
+    end_year: 2021
+    description: "A significant 2019 redesign introduced major visual and technical updates to the 500X while maintaining the Small Wide 4×4 platform. The redesign launched new turbocharged engines including downsized 1.0L and 1.3L FireFly turbo units alongside updated diesel engines. The updated styling included refreshed exterior and interior design, with new technology features and infotainment systems. The North American market received revised engine options optimized for that region."
+
+  - name: "First Generation (2022 Restyling)"
+    start_year: 2022
+    end_year: 2024
+    description: "The 2022 restyling brought another round of updates including the introduction of a new 1.5L FireFly mild hybrid powertrain option with a 48V electric system. Visual updates to the exterior and interior styling continued the 500X's evolution. A soft-top variant called the 500X Dolcevita, featuring a power-retractable canvas roof, was also available during this period. This represents the final iteration of the first-generation 500X before production ended in August 2024, with the 500X eventually being succeeded by the Fiat 600."


### PR DESCRIPTION
- Added references array with Wikipedia article
- Split single generation into four distinct entries capturing facelifts
  - Original 2014-2018 initial generation
  - 2018 facelift with styling updates (2018-2019)
  - 2019 redesign with new engines and major updates (2019-2021)
  - 2022 restyling with mild hybrid variant (2022-2024)
- Updated end_year for original generation to 2018
- Added detailed descriptions for each generation period
- Updated README.md with standard template

Evidence from Wikipedia:
- Infobox: "production = 2014–2024"
- Gallery captions reference "2018 Fiat 500X Urban Look facelift"
- Engine table shows "2019, from redesign launch" for new engines
- Engine table shows "2022, from restyling" for mild hybrid variant

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
